### PR TITLE
Extract and respond with bytes instead of string

### DIFF
--- a/src/cors_proxy.rs
+++ b/src/cors_proxy.rs
@@ -58,7 +58,7 @@ impl CorsProxy {
 
         // Constructing response
         let code = response.status();
-        let body = response.text().await.expect("Can't load response body");
+        let body = response.bytes().await.expect("Can't load response body");
         HttpResponseBuilder::new(code).body(body)
     }
 }


### PR DESCRIPTION
Extracting the body with `response.text()` causes binary blobs to be erroneously escaped. For example:

```bash
$ PORT=8000 cargo run &
$ curl -o original https://github.com/cyqsimon/documented/archive/refs/tags/v0.2.0.tar.gz
$ curl -o proxied http://localhost:8000/https://github.com/cyqsimon/documented/archive/refs/tags/v0.2.0.tar.gz

# the two files should be the same but are not
$ ls -l original proxied
$ md5sums original proxied
```

By extracting the bytes instead, all kinds of files are correctly passed through.